### PR TITLE
gradle rest task and documentation for improving the local development experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,3 +10,51 @@ A neat little project that uses our jenkins utils and helps you to get started a
 1. In `settings.gradle`, change the `rootProject.name` to match your new project name
 1. Run `./gradlew build` from the project root directory
 1. Profit! Start writing your jobs in jobs dir. 
+
+## Creating your jobs in Jenkins
+
+### Creating the seed job
+
+Ultimately, you'll need a "seed job" to run your job files in Jenkins, essentially following [these instructions](https://github.com/jenkinsci/job-dsl-plugin#basic-usage)
+
+Assuming you're using our [jenkins-automation](https://github.com/cfpb/jenkins-automation/) niceties, 
+your seed job will be configured with "multi-scm" and 2 git repos: the `jenkins-automation` repo, 
+and the repo that you're creating by cloning this `jenkins-as-code-starter-project`
+
+### Local development helper
+
+For local development, as you iterate on your job files, it's usually nice to tweak your file locally, 
+create those jobs in a local jenkins, and then push to GitHub when they're working as expected.
+
+To do so, use the gradle `rest` task, which we've included in `jenkins-automation` and lifted nearly verbatim from https://github.com/sheehan/job-dsl-gradle-example (thanks!)
+
+
+`./gradlew rest -Dpattern=<pattern> -DbaseUrl=<baseUrl> [-Dusername=<username>] [-Dpassword=<password>]`
+
+* `pattern` - [ant-style path pattern](https://ant.apache.org/manual/dirtasks.html) of files to include
+* `baseUrl` - base URL of Jenkins server
+* `username` - Jenkins username, if secured
+* `password` - Jenkins password or token, if secured
+* `JAC_ENVIRONMENT` - An environment variable we set in all of our Jenkinses. Defaults to "dev". Used by our `EnvironmentUtils`. See example usage in `jobs/jobs.groovy` in this repo
+* `JAC_HOST` - An environment variable we set in all of our Jenkinses. Defaults to "aws".
+
+This uses a task named `rest` to execute `jenkins.automation.rest.RestApiScriptRunner`, 
+which lives in the `jenkins-automation` repo and is available here since `jenkins-automation` is a dependency.
+
+#### Examples
+
+Run all jobs files in the `jobs` directory against a locally running Jenkins
+
+`./gradlew rest -Dpattern=jobs/** -DbaseUrl=http://localhost:8081`
+
+Run all jobs defined in`jobs/jobs.groovy` against a locally running Jenkins.
+
+`./gradlew rest -Dpattern=jobs/jobs.groovy -DbaseUrl=http://localhost:8081`
+
+Same as above, but override the default JAC_ENVIRONMENT variable if those jobs behave different based on that variable
+`./gradlew rest -Dpattern=jobs/jobs.groovy -DbaseUrl=http://localhost:8081 -DJAC_ENVIRONMENT=prod`
+
+
+Run everything in the `jobs` directory against a remote Jenkins
+
+`./gradlew rest -Dpattern=jobs/** -DbaseUrl=http://dev.jenkins -Dusername=foo -Dpassword=bar`

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,12 @@ task wrapper(type: Wrapper) {
     distributionUrl = "https://services.gradle.org/distributions/gradle-$gradleVersion-all.zip"
 }
 
+task rest(type: JavaExec) {
+    main = 'jenkins.automation.rest.RestApiScriptRunner'
+    classpath = sourceSets.main.runtimeClasspath
+    systemProperties System.getProperties()
+}
+
 sourceSets {
     main {
         groovy {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Nov 12 15:51:31 EST 2015
+#Wed Apr 27 13:19:01 EDT 2016
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.2-all.zip


### PR DESCRIPTION
Add gradle rest task, and documentation, for running job-dsl jobs with gradle against a running Jenkins, for use in a local development workflow
