### PR TITLE
Get the LoadAllScripts test working when jobs inspect our expected Jenkins environment variables

### DIFF
--- a/src/test/groovy/LoadAllScriptsTests.groovy
+++ b/src/test/groovy/LoadAllScriptsTests.groovy
@@ -6,11 +6,17 @@ import spock.lang.Ignore
 import spock.lang.Specification
 
 class LoadAllScriptsTests extends Specification {
-    @Ignore
+    //@Ignore
     void 'test my flow build job'() {
 
         given:
         JobManagement jm = new MemoryJobManagement()
+
+        //for the test, set the params we expect to exist in all our Jenkinses
+        def params = jm.getParameters()
+        params['JAC_ENVIRONMENT'] = "dev"
+        params['JAC_HOST'] = "aws"
+
         List<File> files = []
 
         new File('jobs').eachFileRecurse(FileType.FILES) {


### PR DESCRIPTION
For testing the scripts, ensure the 2 environment vars we expect to exist in all of our jenkinses are present for the test
