### PR TITLE
Updating to latest jobs-dsl-plugin v1.57

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ dependencies {
             {
                 exclude module: 'groovy-all'
             }
-    compile 'com.github.jls5177:jenkins-automation:-SNAPSHOT'
+    compile 'com.github.cfpb:jenkins-automation:-SNAPSHOT'
 
 }
 task wrapper(type: Wrapper) {

--- a/build.gradle
+++ b/build.gradle
@@ -15,12 +15,12 @@ dependencies {
     compile 'org.ini4j:ini4j:0.5.1'
     compile 'org.codehaus.groovy:groovy-all:2.3.11'
     testCompile group: 'junit', name: 'junit', version: '4.11'
-    compile 'org.jenkins-ci.plugins:job-dsl-core:1.47'
+    compile 'org.jenkins-ci.plugins:job-dsl-core:1.57'
     testCompile('org.spockframework:spock-core:0.7-groovy-2.0')
             {
                 exclude module: 'groovy-all'
             }
-    compile 'com.github.cfpb:jenkins-automation:-SNAPSHOT'
+    compile 'com.github.jls5177:jenkins-automation:-SNAPSHOT'
 
 }
 task wrapper(type: Wrapper) {

--- a/src/test/groovy/LoadAllScriptsTests.groovy
+++ b/src/test/groovy/LoadAllScriptsTests.groovy
@@ -2,7 +2,6 @@ import groovy.io.FileType
 import javaposse.jobdsl.dsl.DslScriptLoader
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.MemoryJobManagement
-import javaposse.jobdsl.dsl.ScriptRequest
 import spock.lang.Ignore
 import spock.lang.Specification
 
@@ -33,7 +32,7 @@ class LoadAllScriptsTests extends Specification {
 
         when:
         files.each { file ->
-            new DslScriptLoader(jm).runScripts([new ScriptRequest(file.text)])
+            new DslScriptLoader(jm).runScript(file.text)
         }
 
         then:

--- a/src/test/groovy/LoadAllScriptsTests.groovy
+++ b/src/test/groovy/LoadAllScriptsTests.groovy
@@ -2,6 +2,7 @@ import groovy.io.FileType
 import javaposse.jobdsl.dsl.DslScriptLoader
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.dsl.MemoryJobManagement
+import javaposse.jobdsl.dsl.ScriptRequest
 import spock.lang.Ignore
 import spock.lang.Specification
 
@@ -32,7 +33,7 @@ class LoadAllScriptsTests extends Specification {
 
         when:
         files.each { file ->
-            DslScriptLoader.runDslEngine file.text, jm
+            new DslScriptLoader(jm).runScripts([new ScriptRequest(file.text)])
         }
 
         then:


### PR DESCRIPTION
In a recent build the runDslEngine() method was deprecated. This
commit updated the tests and gradle to use the latest version.

This change also requires a change to the jenkins-automation repo (also created a pull request for this change).